### PR TITLE
Fix Split of Update and Show Logic for Favorites and Sorties, Remove Redundant Await

### DIFF
--- a/js/stories.js
+++ b/js/stories.js
@@ -103,7 +103,7 @@ async function deleteStoryFromPage(e) {
   await putUserStoriesOnPage();
 
   // re-generates homepage story list 
-  await putStoriesOnPage();
+  updateStoriesOnPage();
 }
 
 // event listener to trash can icon, when clicked, will call deleteStoryFromPage to delete the story
@@ -111,8 +111,7 @@ $ownStories.on("click", ".trash-can", deleteStoryFromPage);
 
 /** Gets list of stories from server, generates their HTML, and puts on page. */
 
-function putStoriesOnPage() {
-  // clears all stories under $allStoriesList ol
+function updateStoriesOnPage() {
   $allStoriesList.empty();
 
   // loop through all of our stories and generate HTML for them
@@ -120,14 +119,18 @@ function putStoriesOnPage() {
     const $story = generateStoryMarkup(story);
     $allStoriesList.append($story);
   }
+}
+
+function putStoriesOnPage() {
+  // clears all stories under $allStoriesList ol
+  updateStoriesOnPage();
 
   // generates updated story list 
   $allStoriesList.show();
+
 }
 
-// HTML markup for favourited stories 
-function displayFavoriteList() {
-  // clears all stories under $favoritedStories ol
+function updateFavoriteList() {
   $favoritedStories.empty();
 
   // checks ig currentUser has favourites
@@ -141,6 +144,12 @@ function displayFavoriteList() {
   } else {
     $favoritedStories.append("<b><h5>No favorites added!</h5></b>");
   }
+}
+
+// HTML markup for favourited stories 
+function displayFavoriteList() {
+  // clears all stories under $favoritedStories ol
+  updateFavoriteList();
   $favoritedStories.show();
 }
 

--- a/js/user.js
+++ b/js/user.js
@@ -119,5 +119,5 @@ function updateUIOnUserLogin() {
   hidePageComponents();
   $allStoriesList.show();
   updateNavOnLogin();
-  displayFavoriteList();
+  updateFavoriteList();
 }


### PR DESCRIPTION
### Summary:
This PR addresses two key issues:

1. **Split Update Page from Show Logic:**
   - Separated the logic for `update` and `show` to avoid unnecessary triggering of the `show` method during updates. Previously, both the `favorites` and `sorties` components would trigger the `show` logic on `update`, which is redundant and could cause performance issues. This fix ensures that updates no longer automatically invoke `show`, providing a more efficient update flow.

2. **Removed Needless Await:**
   - Cleaned up the code by removing redundant `await` calls that are not needed for the operation. This improves code readability and execution efficiency.

### Changes:
- Refactored the logic for handling `update` and `show` events for both `favorites` and `sorties`.
- Removed unnecessary `await` statements.

### Testing:
- Manual

### Impact:
- Improves first render behavior.

